### PR TITLE
Allow desc element for SVGs

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -897,6 +897,7 @@ declare global {
 			circle: SVGAttributes;
 			clipPath: SVGAttributes;
 			defs: SVGAttributes;
+			desc: SVGAttributes;
 			ellipse: SVGAttributes;
 			feBlend: SVGAttributes;
 			feColorMatrix: SVGAttributes;


### PR DESCRIPTION
Add `<desc>` elements to the Typescript typings for accessibility.

Fixes https://github.com/developit/preact/issues/1296